### PR TITLE
Fix all Pipeline Module Parameters being sent to cuda:0

### DIFF
--- a/deepspeed/runtime/pipe/module.py
+++ b/deepspeed/runtime/pipe/module.py
@@ -186,7 +186,7 @@ class PipelineModule(nn.Module):
 
         #with torch.random.fork_rng(devices=[torch.cuda.current_device()]):
         self._build()
-        self.to('cuda')
+        self.to(f'cuda:{self.global_rank}')
 
         self.tied_comms = self._index_tied_modules()
         self._synchronize_tied_weights()


### PR DESCRIPTION
so, it seems that internally, PipelineModule calls self.to('cuda'). This appears to send the model parameters to GPU0, for *every visible gpu* running the deepspeed script, and makes scaling up difficult. 

Instead, we can send the parameters to the current device with `self.to(f'cuda:{self.global_rank}')`.

I'm actually unsure as to why the entire model's parameters are getting sent to one single GPU at this stage at all - aren't they meant to be partitioned equally across all GPUs?

Would appreciate anyone clearing this up for me.