### PR TITLE
Move hooked embeddings to cpu to avoid oom

### DIFF
--- a/deepspeed/runtime/engine.py
+++ b/deepspeed/runtime/engine.py
@@ -242,7 +242,7 @@ class DeepSpeedEngine(Module):
                     return
             else:
                 key = module.__class__.__name__
-            self.layer_outputs[key] = output 
+            self.layer_outputs[key] = [o.cpu() if torch.is_tensor(o) else o for o in output]
 
         def get_all_layers(net):
             for name, layer in net._modules.items():


### PR DESCRIPTION
Keeping all hooked layer outputs on GPU quickly leads to out of memory issues. This PR moves all embeddings to cpu in layer hook.