### PR TITLE
Make checkpoint utilities compatible with NeoX

### DIFF
--- a/deepspeed/checkpoint/__init__.py
+++ b/deepspeed/checkpoint/__init__.py
@@ -2,7 +2,7 @@
 
 from .reshape_meg_2d import reshape_meg_2d_parallel
 
-from .deepspeed_checkpoint import DeepSpeedCheckpoint
+from .deepspeed_checkpoint import DeepSpeedCheckpoint, NeoxCheckpoint
 
 from .utils import (get_layer_ckpt_name_for_rank,
                     get_model_ckpt_name_for_rank,

--- a/deepspeed/checkpoint/deepspeed_checkpoint.py
+++ b/deepspeed/checkpoint/deepspeed_checkpoint.py
@@ -88,6 +88,18 @@ class DeepSpeedCheckpoint(object):
             FINAL_LAYER_NORM_INDEX)
         self._build_global_state()
 
+    @property
+    def original_tp_degree(self):
+        return self.zero_checkpoint.get_src_tp_degree()
+
+    @property
+    def original_pp_degree(self):
+        return self.zero_checkpoint.get_src_pp_degree()
+
+    @property
+    def zero_files(self):
+        return self.zero_checkpoint.file_list
+
     def is_change_tp_degree(self):
         return self.tp_degree != self.zero_checkpoint.get_src_tp_degree()
 
@@ -312,6 +324,21 @@ class DeepSpeedCheckpoint(object):
                 MODEL_FILE_PREFIX,
                 LAYER_FILE_PREFIX,
                 f'{LAYER_FILE_PREFIX}01'
+        ]:
+            ckpt_files = get_files_with_prefix(file_list, file_prefix)
+            assert len(ckpt_files) > 0, f'{dir} seems a bogus DeepSpeed checkpoint folder: Cannot find {file_prefix}* files in there.'
+
+
+class NeoxCheckpoint(DeepSpeedCheckpoint):
+
+    def _validate_folder(self, dir):
+        basic_folder_validation(dir)
+
+        file_list = get_files(dir)
+
+        for file_prefix in [
+                MODEL_FILE_PREFIX,
+                LAYER_FILE_PREFIX
         ]:
             ckpt_files = get_files_with_prefix(file_list, file_prefix)
             assert len(ckpt_files) > 0, f'{dir} seems a bogus DeepSpeed checkpoint folder: Cannot find {file_prefix}* files in there.'

--- a/deepspeed/checkpoint/reshape_3d_utils.py
+++ b/deepspeed/checkpoint/reshape_3d_utils.py
@@ -76,10 +76,20 @@ class model_3d_desc(object):
         return len(err_msg) == 0, err_msg
 
 
+def get_num_pp0_files(file_list):
+    num_layer1_files = len(get_files_with_prefix(file_list, f'{LAYER_FILE_PREFIX}01'))
+    num_layer2_files = len(get_files_with_prefix(file_list, f'{LAYER_FILE_PREFIX}02'))
+    if (num_layer1_files > 0) or (num_layer2_files == 0):
+        return num_layer1_files
+    else:
+        return num_layer2_files
+
+
+
 def get_model_3d_descriptor(dir):
     file_list = get_files(dir)
     zero_file_list = get_zero_files(dir)
-    num_pp0_files = len(get_files_with_prefix(file_list, f'{LAYER_FILE_PREFIX}01'))
+    num_pp0_files = get_num_pp0_files(file_list)
     if num_pp0_files > 0:
         tp_degree = num_pp0_files
         pp_degree = len(get_files_with_prefix(file_list, MODEL_FILE_PREFIX)) // tp_degree

--- a/deepspeed/checkpoint/reshape_utils.py
+++ b/deepspeed/checkpoint/reshape_utils.py
@@ -3,7 +3,7 @@
 import os
 import torch
 from collections import OrderedDict
-from .constants import (ZERO_FILE_PREFIX, FP16_ZERO_FILE_PREFIX, BF16_ZERO_FILE_PREFIX)
+from .constants import (ZERO_FILE_PREFIX, FP16_ZERO_FILE_PREFIX, BF16_ZERO_FILE_PREFIX, PARTITION_COUNT)
 
 
 def basic_folder_validation(dir):
@@ -61,12 +61,25 @@ def _key_list_to_string(key_list):
     return '.'.join(key_list)
 
 
+def _to_list_if_int(list_or_int):
+    if isinstance(list_or_int, int):
+        return [list_or_int]
+    else:
+        return list_or_int
+
+
 def merge_state_dict(dict_a, dict_b, key_list):
     merged_dict = type(dict_a)({})
 
     for key, value in dict_b.items():
         if key in dict_a.keys():
-            merged_dict[key] = merge_state(dict_a[key], dict_b[key], [str(key)])
+            # TODO: Fix ugliest hack ever
+            if key == PARTITION_COUNT:
+                count_a = _to_list_if_int(dict_a[key])
+                count_b = _to_list_if_int(dict_b[key])
+                merged_dict[key] = merge_state(count_a, count_b, [str(key)])
+            else:
+                merged_dict[key] = merge_state(dict_a[key], dict_b[key], [str(key)])
         else:
             merged_dict[key] = value
 

--- a/deepspeed/checkpoint/zero_checkpoint.py
+++ b/deepspeed/checkpoint/zero_checkpoint.py
@@ -135,14 +135,17 @@ class ZeROCheckpoint(object):
             return None
 
         base_optimizer_state = optimizer_state.get(BASE_OPTIMIZER_STATE, None)
-        if base_optimizer_state is None:
+        if base_optimizer_state is None or isinstance(base_optimizer_state, list):
             return None
 
         return base_optimizer_state.get(GROUP_STATE_KEY, None)
 
     def _update_partition_count(self, sd):
         partition_counts = self._get_optimizer_state(sd, PARTITION_COUNT)
-        if partition_counts:
-            num_groups = len(partition_counts)
+        if isinstance(partition_counts, int):
+            partition_counts = [partition_counts]
+        num_partitions = len(partition_counts)
+        if num_partitions:
+            # num_groups = len(partition_counts)
             sd[OPTIMIZER_STATE_DICT][PARTITION_COUNT] = [self.target_3d.dp_degree
-                                                         ] * num_groups
+                                                         ] * num_partitions


### PR DESCRIPTION
Small changes to the DeepSpeed checkpoint utilities to make them compatible with GPT-NeoX, e.g. NeoX checkpoints lack a `layer01` weight file.