### PR TITLE
Prevent zero optimizer loading when finetuning a model and using zero_optimization

### DIFF
--- a/deepspeed/runtime/engine.py
+++ b/deepspeed/runtime/engine.py
@@ -2779,17 +2779,18 @@ class DeepSpeedEngine(Module):
                                                          load_module_only=load_module_only,
                                                          custom_load_fn=custom_load_fn)
 
-        load_zero_checkpoint = self.zero_optimization() or self.bfloat16_enabled()
-        if load_zero_checkpoint and load_path is not None:
-            success = self._load_zero_checkpoint(
-                load_dir,
-                tag,
-                load_optimizer_states=load_optimizer_states)
-            if not success:
-                self.optimizer._restore_from_bit16_weights()
+        if not self.load_module_only and load_optimizer_states:
+            load_zero_checkpoint = self.zero_optimization() or self.bfloat16_enabled()
+            if load_zero_checkpoint and load_path is not None:
+                success = self._load_zero_checkpoint(
+                    load_dir,
+                    tag,
+                    load_optimizer_states=load_optimizer_states)
+                if not success:
+                    self.optimizer._restore_from_bit16_weights()
 
-        if self.zero_optimization_partition_weights():
-            self.optimizer.checkpoint_event_epilogue()
+            if self.zero_optimization_partition_weights():
+                self.optimizer.checkpoint_event_epilogue()
 
         return load_path, client_states
 

--- a/deepspeed/runtime/engine.py
+++ b/deepspeed/runtime/engine.py
@@ -2779,7 +2779,7 @@ class DeepSpeedEngine(Module):
                                                          load_module_only=load_module_only,
                                                          custom_load_fn=custom_load_fn)
 
-        if not self.load_module_only and load_optimizer_states:
+        if not load_module_only and load_optimizer_states:
             load_zero_checkpoint = self.zero_optimization() or self.bfloat16_enabled()
             if load_zero_checkpoint and load_path is not None:
                 success = self._load_zero_checkpoint(


### PR DESCRIPTION
The proposed change prevents loading zero optimizer checkpoints when finetune=True. It goes along with the recently merged PR #927 to gpt-neox (https://github.com/EleutherAI/gpt-neox/pull/927).