### PR TITLE
Update Slurm Launcher

### DIFF
--- a/deepspeed/launcher/multinode_runner.py
+++ b/deepspeed/launcher/multinode_runner.py
@@ -424,10 +424,10 @@ class SlurmRunner(MultiNodeRunner):
         ] + split(self.args.launcher_args)
 
         if getattr(self.args, 'comment', ''):
-            srun_cmd += ['--account', self.args.comment]
+            srun_cmd += ['--comment', self.args.comment]
 
         if getattr(self.args, 'account', ''):
-            srun_cmd += ['--comment', self.args.comment]
+            srun_cmd += ['--account', self.args.account]
 
         if self.args.include != "":
             srun_cmd.append('--nodelist')

--- a/deepspeed/launcher/multinode_runner.py
+++ b/deepspeed/launcher/multinode_runner.py
@@ -424,12 +424,11 @@ class SlurmRunner(MultiNodeRunner):
         ] + split(self.args.launcher_args)
 
         if getattr(self.args, 'comment', ''):
-            srun_cmd += ['--comment', self.args.comment]
+            srun_cmd += ['--account', self.args.comment]
 
         if self.args.include != "":
             srun_cmd.append('--nodelist')
             srun_cmd.append(self._pdsh_include_to_nodelist(self.args.include)) 
-            srun_cmd += ['--comment', self.args.slurm_comment]
 
         if self.args.num_nodes > 0:
             srun_cmd.append('--nodes')

--- a/deepspeed/launcher/multinode_runner.py
+++ b/deepspeed/launcher/multinode_runner.py
@@ -426,6 +426,9 @@ class SlurmRunner(MultiNodeRunner):
         if getattr(self.args, 'comment', ''):
             srun_cmd += ['--account', self.args.comment]
 
+        if getattr(self.args, 'account', ''):
+            srun_cmd += ['--comment', self.args.comment]
+
         if self.args.include != "":
             srun_cmd.append('--nodelist')
             srun_cmd.append(self._pdsh_include_to_nodelist(self.args.include)) 

--- a/deepspeed/launcher/runner.py
+++ b/deepspeed/launcher/runner.py
@@ -177,7 +177,14 @@ def parse_args(args=None):
         "--comment",
         default="",
         type=str,
-        help="A comment that can be used for metadata."
+        help="A comment that can be used for metadata. Used to pass --comment argument to srun in Slurm launcher"
+    )
+
+    parser.add_argument(
+        "--account",
+        default="",
+        type=str,
+        help="Used to pass --account argument to srun in Slurm launcher"
     )
 
     parser.add_argument("--elastic_training",


### PR DESCRIPTION
This PR changes the the SLURM launcher in two ways:

1. Due to what looks like a unintended consequence of a merge commit, `self.args.slurm_comment` was still referenced, and the launcher would include `--comment` even when `self.args.comment` was an empty string.
2. We now want to be using `--account` rather than `--comment` for assigning accounting groups to a given job. (if this is too specific to the Stability cluster, happy to find some way to allow users to toggle between using `--account` and `--comment`

I've left the `comment` argument in GPT-NeoX with its same name, but can update it to something like `slurm_account` if that is preferred.


cc @Quentin-Anthony 