### PR TITLE
feat: fix PipelineEngine init logging error

### DIFF
--- a/deepspeed/runtime/pipe/engine.py
+++ b/deepspeed/runtime/pipe/engine.py
@@ -136,7 +136,7 @@ class PipelineEngine(DeepSpeedEngine):
         assert isinstance(self._config.pipeline['grad_partitioned'], bool)
         self.is_pipe_partitioned = self.is_model_parallel and self._config.pipeline['pipe_partitioned']
         self.is_grad_partitioned = self.is_model_parallel and self._config.pipeline['grad_partitioned']
-        logger.info(f'is_pipe_partitioned= {self.is_pipe_partitioned}',
+        logger.info(f'is_pipe_partitioned= {self.is_pipe_partitioned} '
                     f'is_grad_partitioned= {self.is_grad_partitioned}')
 
         model_parameters = filter(lambda p: p.requires_grad, self.module.parameters())


### PR DESCRIPTION
The current behavior causes a silent logging error (training will continue, but dumps logging error due to improper format string)

Error occurs only when doing pipeline parallel training:

```shell
--- Logging error ---
Traceback (most recent call last):
  File "/usr/lib64/python3.9/logging/__init__.py", line 1079, in emit
    msg = self.format(record)
  File "/usr/lib64/python3.9/logging/__init__.py", line 923, in format
    return fmt.format(record)
  File "/usr/lib64/python3.9/logging/__init__.py", line 659, in format
    record.message = record.getMessage()
  File "/usr/lib64/python3.9/logging/__init__.py", line 363, in getMessage
    msg = msg % self.args
TypeError: not all arguments converted during string formatting
Call stack:
  File "/gpt-neox/train.py", line 34, in <module>
    main()
  File "/gpt-neox/train.py", line 30, in main
    pretrain(neox_args=neox_args)
  File "/gpt-neox/megatron/training.py", line 194, in pretrain
    model, optimizer, lr_scheduler = setup_model_and_optimizer(
  File "/gpt-neox/megatron/training.py", line 667, in setup_model_and_optimizer
    model, optimizer, _, lr_scheduler = deepspeed.initialize(
  File "/venv/lib64/python3.9/site-packages/deepspeed/__init__.py", line 186, in initialize
    engine = PipelineEngine(args=args,
  File "/venv/lib64/python3.9/site-packages/deepspeed/runtime/pipe/engine.py", line 139, in __init__
    logger.info(f'is_pipe_partitioned= {self.is_pipe_partitioned}',
Message: 'is_pipe_partitioned= True'
Arguments: ('is_grad_partitioned= True',)
```

Minimal reproduction of root cause:

```shell
>>> import logging
>>> logging.error(f"hi {1}", "hi {2}")
--- Logging error ---
Traceback (most recent call last):
  File "/usr/lib64/python3.9/logging/__init__.py", line 1079, in emit
    msg = self.format(record)
  File "/usr/lib64/python3.9/logging/__init__.py", line 923, in format
    return fmt.format(record)
  File "/usr/lib64/python3.9/logging/__init__.py", line 659, in format
    record.message = record.getMessage()
  File "/usr/lib64/python3.9/logging/__init__.py", line 363, in getMessage
    msg = msg % self.args
TypeError: not all arguments converted during string formatting
Call stack:
  File "<stdin>", line 1, in <module>
Message: 'hi 1'
```

After change, pipeline parallel training successfully prints the logs:

```shell
[2024-03-02 11:08:33,055] [INFO] [engine.py:139:__init__] is_pipe_partitioned= True is_grad_partitioned= True
[2024-03-02 11:08:33,058] [INFO] [engine.py:139:__init__] is_pipe_partitioned= True is_grad_partitioned= True
[2024-03-02 11:08:33,059] [INFO] [engine.py:139:__init__] is_pipe_partitioned= True is_grad_partitioned= True
[2024-03-02 11:08:33,060] [INFO] [engine.py:139:__init__] is_pipe_partitioned= True is_grad_partitioned= True
[2024-03-02 11:08:33,060] [INFO] [engine.py:139:__init__] is_pipe_partitioned= True is_grad_partitioned= True
[2024-03-02 11:08:33,062] [INFO] [engine.py:139:__init__] is_pipe_partitioned= True is_grad_partitioned= True
[2024-03-02 11:08:33,062] [INFO] [engine.py:139:__init__] is_pipe_partitioned= True is_grad_partitioned= True
```