### PR TITLE
Allow for preventing 16-bit cast of marked modules

### DIFF
--- a/deepspeed/runtime/engine.py
+++ b/deepspeed/runtime/engine.py
@@ -1074,11 +1074,25 @@ class DeepSpeedEngine(Module):
         if self.fp16_enabled():
             if is_zero_init_model:
                 self.__check_params(self.module, torch.half)
-            self.module.half()
+            # selectively avoid casting specially 
+            # marked parameters to 16-bit
+            self.module._apply(
+                lambda t: t.half() if (
+                    t.is_floating_point() and 
+                    not getattr(t, "_deepspeed_no_cast", False)
+                ) else t
+            )
         elif self.bfloat16_enabled():
             if is_zero_init_model:
                 self.__check_params(self.module, torch.bfloat16)
-            self.module.bfloat16()
+            # selectively avoid casting specially 
+            # marked parameters to 16-bit
+            self.module._apply(
+                lambda t: t.bfloat16() if (
+                    t.is_floating_point() and 
+                    not getattr(t, "_deepspeed_no_cast", False)
+                ) else t
+            )
         else:
             self.__check_params(self.module, torch.float)
 


### PR DESCRIPTION
This PR allows for one to mark a given model parameter with `p._deepspeed_no_cast = True` to allow it to not be cast into 16-bit by DeepSpeed.

Used this to train a mamba-160m, keeping A_log and D params in fp32 throughout, which performed on-par with paper's reported results. However, if this change seems like a bad idea or is likely to break things, would be glad to know what to check for.

This should also allow us to keep `inv_freq` in rotary embeddings in fp32!