### PR TITLE
Resolve gradient accumulation memory leak

### DIFF
--- a/deepspeed/runtime/pipe/engine.py
+++ b/deepspeed/runtime/pipe/engine.py
@@ -810,6 +810,7 @@ class PipelineEngine(DeepSpeedEngine):
         # mechanisms.
         if self.is_last_stage():
             super().backward(self.loss)
+            self.mem_status('AFTER BWD')
             # Free up the memory from the output of forward()
             self.pipe_buffers['outputs'][buffer_id] = None
             self.pipe_buffers['output_tensors'][buffer_id] = None

--- a/deepspeed/runtime/pipe/engine.py
+++ b/deepspeed/runtime/pipe/engine.py
@@ -810,7 +810,9 @@ class PipelineEngine(DeepSpeedEngine):
         # mechanisms.
         if self.is_last_stage():
             super().backward(self.loss)
-            self.mem_status('AFTER BWD')
+            # Free up the memory from the output of forward()
+            self.pipe_buffers['outputs'][buffer_id] = None
+            self.pipe_buffers['output_tensors'][buffer_id] = None
             return
 
         outputs = self.pipe_buffers['outputs'][buffer_id]

--- a/deepspeed/runtime/zero/stage_1_and_2.py
+++ b/deepspeed/runtime/zero/stage_1_and_2.py
@@ -1843,7 +1843,13 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
             if self.cpu_offload:
                 self.reset_cpu_buffers()
             else:
+                # Make sure to release ipg buffers in case of overflow
                 self.averaged_gradients = {}
+                self._release_ipg_buffers()
+                self.grads_in_ipg_bucket = []
+                self.params_in_ipg_bucket = []
+                self.ipg_bucket_has_moe_params = False
+                self.elements_in_ipg_bucket = 0
 
             see_memory_usage('After overflow after clearing gradients')
 


### PR DESCRIPTION
I found three main sources of memory increase:
1. With grad_accum > 1, activations from the current iteration aren’t freed until two subsequent forward passes are completed. This results in two large activation buffers being kept in memory at all times. 
Fix: Freed activations immediately after the backward pass, reducing memory usage for grad_accum=2 to match grad_accum=1.
2. With gradient overflow (due to large batch size), DS skips the current iteration (no optimizer step) and updates the loss scale. This is happening with grad_accum>4, and the skip prevents some reduction buffers from being freed correctly. They persist throughout training.
Fix: Explicitly free IPG buffers when an overflow is detected.
3. With grad_accum > 1, gradients accumulate via multiple loss.backward() calls before the optimizer step, with PyTorch handling accumulation internally. Memory profiling shows that PyTorch allocates an additional copy of FP16 gradients during the second backward pass instead of performing in-place operations, introducing a fixed overhead. Since this behavior is internal to PyTorch, no fix was applied.

Tested on a 1-3B GPT-NeoX model configuration.
Loss values and iteration time are identical to the main branch.